### PR TITLE
re-style subtitle to use tag

### DIFF
--- a/odysseus/convertFtbQuests.ts
+++ b/odysseus/convertFtbQuests.ts
@@ -492,7 +492,7 @@ export const convertFtbQuests = async (input: QuestInputFileSystem, output: Ques
                         title: questTitle,
                         description: escapeFormatters([
                             ...questSubtitle ? [
-                                `<h2>${questSubtitle}</h2>`,
+                                `<subtitle id="${quest.id}" bold="true" centered="true" color="lightgray"/>`,
                                 '<hr/>',
                             ] : [],
 


### PR DESCRIPTION
there's a subtitle tag! And when it's bold, centred, and light grey, it stops overshadowing the title so much.

![image](https://github.com/terrarium-earth/odysseus/assets/55819817/144167d6-e882-4151-a290-89aca885e759)
