### PR TITLE
hide invisible quests

### DIFF
--- a/odysseus/convertFtbQuests.ts
+++ b/odysseus/convertFtbQuests.ts
@@ -240,6 +240,7 @@ type Chapter = QuestObject & {
         min_required_dependencies?: number;
         dependencies?: number[] | string[];
         hide?: boolean;
+        invisible?: boolean;
         dependency_requirement: 'all_completed' | 'one_completed' | 'all_started' | 'one_started';
         hide_text_until_complete?: boolean;
         size?: number;
@@ -478,7 +479,7 @@ export const convertFtbQuests = async (input: QuestInputFileSystem, output: Ques
 
                 const heraclesQuest: HeraclesQuest = {
                     settings: {
-                        hidden: quest.hide
+                        hidden: quest.hide || quest.invisible
                     },
 
                     dependencies: areNumericIds(quest.dependencies) ?


### PR DESCRIPTION
FTB quests has a setting called `invisible` that hides a quest until it's completed. This is a much stronger setting than hide, so it's often not set together - meaning I had a bunch of random completely visible quests in heracles.

after https://github.com/terrarium-earth/Heracles/issues/102 is fixed up this will change again.