### PR TITLE
Preserve FTBQ quest shape options

### DIFF
--- a/odysseus/HeraclesQuest.ts
+++ b/odysseus/HeraclesQuest.ts
@@ -254,7 +254,8 @@ export type HeraclesQuest = {
     display?: {
         icon?: HeraclesQuestIcon;
 
-        icon_background?: 'heracles:textures/gui/quest_backgrounds/default.png' | 'heracles:textures/gui/quest_backgrounds/circles.png';
+        //icon_background?: 'heracles:textures/gui/quest_backgrounds/default.png' | 'heracles:textures/gui/quest_backgrounds/circles.png';
+        icon_background?: string;
         title?: Component;
         subtitle?: Component;
         description?: string[];

--- a/odysseus/HeraclesQuest.ts
+++ b/odysseus/HeraclesQuest.ts
@@ -253,8 +253,6 @@ export type HeraclesQuestReward = HeraclesQuestElement & ({
 export type HeraclesQuest = {
     display?: {
         icon?: HeraclesQuestIcon;
-
-        //icon_background?: 'heracles:textures/gui/quest_backgrounds/default.png' | 'heracles:textures/gui/quest_backgrounds/circles.png';
         icon_background?: string;
         title?: Component;
         subtitle?: Component;

--- a/odysseus/convertFtbQuests.ts
+++ b/odysseus/convertFtbQuests.ts
@@ -382,6 +382,21 @@ function truncateLong(value: Long | undefined) {
     return Number(value)
 }
 
+function iconBackgroundTexture(iconBackground: QuestShape | undefined) {
+	switch (iconBackground) {
+		case 'circle':	{ return 'heracles:textures/gui/quest_backgrounds/circles.png' }
+		case 'square':	{ return 'heracles:textures/gui/quest_backgrounds/squares.png' }
+		case 'rsquare': { return 'heracles:textures/gui/quest_backgrounds/rsquares.png' }
+		case 'diamond': { return 'heracles:textures/gui/quest_backgrounds/diamonds.png' }
+		case 'pentagon':{ return 'heracles:textures/gui/quest_backgrounds/pentagons.png' }
+		case 'hexagon': { return 'heracles:textures/gui/quest_backgrounds/hexagons.png' }
+		case 'octagon': { return 'heracles:textures/gui/quest_backgrounds/octagons.png' }
+		case 'gear': 		{ return 'heracles:textures/gui/quest_backgrounds/gears.png' }
+		case 'heart':		{ return 'heracles:textures/gui/quest_backgrounds/hearts.png' }
+		case undefined: { return undefined }
+	}
+}
+
 export const convertFtbQuests = async (input: QuestInputFileSystem, output: QuestOutputFileSystem) => {
     const readSNbtFile = async (name: string) =>
         parseStringifiedNbt(await input.readFile(name), name);
@@ -475,7 +490,9 @@ export const convertFtbQuests = async (input: QuestInputFileSystem, output: Ques
                 const questTitle = quest.title ? formatString(quest.title) : inferredData?.title;
                 const questSubtitle = quest.subtitle ? formatString(quest.subtitle) : undefined;
                 const questIcon = quest.icon ? convertIcon(quest.icon) : inferredData?.icon;
-
+                
+                const iconBackground = iconBackgroundTexture(quest.shape ?? chapter.default_quest_shape ?? questFile.default_quest_shape)
+                                
                 const heraclesQuest: HeraclesQuest = {
                     settings: {
                         hidden: quest.hide
@@ -510,10 +527,8 @@ export const convertFtbQuests = async (input: QuestInputFileSystem, output: Ques
                         ]),
 
                         icon: questIcon,
-
-                        icon_background: (quest.shape ?? chapter.default_quest_shape ?? questFile.default_quest_shape) === 'circle' ?
-                            'heracles:textures/gui/quest_backgrounds/circles.png' :
-                            undefined,
+                        
+                        icon_background: iconBackground,
 
                         subtitle: questSubtitle ? {
                             text: questSubtitle


### PR DESCRIPTION
The aim is to preserve FTBQ quest shape options.

Currently Odysseus is throwing away this information for any options other than 'circle'; all other shape options become "default.png".

This PR was motivated by the assumption that it's easier to address missing texture issues, or edit a single line in affected quest files, than it would be to, in a second pass after Odysseus is done, extract the original shape choices from the FTBQ chapter files and map them into their many Heracles quest files.

A critique: with the current default quest shapes in Heracles, with output from this patch, every option but 'circle' will render as a missing texture (the pink and black checkerboard).

Perhaps then this could be an optional behavior controlled by a command line flag for odysseus-cli?

I have made a set of simple background textures for Heracles, encompassing all the shape options FTBQ has. I can PR that to Heracles too.

[ For Heracles, a change to have it _default_ to 'default.png' for missing textures might be desirable, but that's an issue for that repo, xD ]
