### PR TITLE
Preserve FTBQ quest icon background shape choices

### DIFF
--- a/odysseus/HeraclesQuest.ts
+++ b/odysseus/HeraclesQuest.ts
@@ -253,8 +253,7 @@ export type HeraclesQuestReward = HeraclesQuestElement & ({
 export type HeraclesQuest = {
     display?: {
         icon?: HeraclesQuestIcon;
-
-        icon_background?: 'heracles:textures/gui/quest_backgrounds/default.png' | 'heracles:textures/gui/quest_backgrounds/circles.png';
+        icon_background?: string;
         title?: Component;
         subtitle?: Component;
         description?: string[];

--- a/odysseus/HeraclesQuest.ts
+++ b/odysseus/HeraclesQuest.ts
@@ -253,7 +253,7 @@ export type HeraclesQuestReward = HeraclesQuestElement & ({
 export type HeraclesQuest = {
     display?: {
         icon?: HeraclesQuestIcon;
-        icon_background?: string;
+        icon_background?: ResourceLocation;
         title?: Component;
         subtitle?: Component;
         description?: string[];

--- a/odysseus/convertFtbQuests.ts
+++ b/odysseus/convertFtbQuests.ts
@@ -383,19 +383,8 @@ function truncateLong(value: Long | undefined) {
     return Number(value)
 }
 
-function iconBackgroundTexture(iconBackground: QuestShape | undefined) {
-	switch (iconBackground) {
-		case 'circle': { return 'heracles:textures/gui/quest_backgrounds/circles.png' }
-		case 'square': { return 'heracles:textures/gui/quest_backgrounds/squares.png' }
-		case 'rsquare': { return 'heracles:textures/gui/quest_backgrounds/rsquares.png' }
-		case 'diamond': { return 'heracles:textures/gui/quest_backgrounds/diamonds.png' }
-		case 'pentagon': { return 'heracles:textures/gui/quest_backgrounds/pentagons.png' }
-		case 'hexagon': { return 'heracles:textures/gui/quest_backgrounds/hexagons.png' }
-		case 'octagon': { return 'heracles:textures/gui/quest_backgrounds/octagons.png' }
-		case 'gear': { return 'heracles:textures/gui/quest_backgrounds/gears.png' }
-		case 'heart': { return 'heracles:textures/gui/quest_backgrounds/hearts.png' }
-		case undefined: { return undefined }
-	}
+function iconBackgroundTexture(iconBackground: QuestShape | undefined): ResourceLocation | undefined {
+	return iconBackground === undefined ? undefined : `heracles:textures/gui/quest_backgrounds/${iconBackground}s.png`
 }
 
 export const convertFtbQuests = async (input: QuestInputFileSystem, output: QuestOutputFileSystem) => {

--- a/odysseus/convertFtbQuests.ts
+++ b/odysseus/convertFtbQuests.ts
@@ -385,15 +385,15 @@ function truncateLong(value: Long | undefined) {
 
 function iconBackgroundTexture(iconBackground: QuestShape | undefined) {
 	switch (iconBackground) {
-		case 'circle':	{ return 'heracles:textures/gui/quest_backgrounds/circles.png' }
-		case 'square':	{ return 'heracles:textures/gui/quest_backgrounds/squares.png' }
+		case 'circle': { return 'heracles:textures/gui/quest_backgrounds/circles.png' }
+		case 'square': { return 'heracles:textures/gui/quest_backgrounds/squares.png' }
 		case 'rsquare': { return 'heracles:textures/gui/quest_backgrounds/rsquares.png' }
 		case 'diamond': { return 'heracles:textures/gui/quest_backgrounds/diamonds.png' }
-		case 'pentagon':{ return 'heracles:textures/gui/quest_backgrounds/pentagons.png' }
+		case 'pentagon': { return 'heracles:textures/gui/quest_backgrounds/pentagons.png' }
 		case 'hexagon': { return 'heracles:textures/gui/quest_backgrounds/hexagons.png' }
 		case 'octagon': { return 'heracles:textures/gui/quest_backgrounds/octagons.png' }
-		case 'gear': 		{ return 'heracles:textures/gui/quest_backgrounds/gears.png' }
-		case 'heart':		{ return 'heracles:textures/gui/quest_backgrounds/hearts.png' }
+		case 'gear': { return 'heracles:textures/gui/quest_backgrounds/gears.png' }
+		case 'heart': { return 'heracles:textures/gui/quest_backgrounds/hearts.png' }
 		case undefined: { return undefined }
 	}
 }

--- a/odysseus/convertFtbQuests.ts
+++ b/odysseus/convertFtbQuests.ts
@@ -15,7 +15,7 @@ const enum ObserveType {
     ENTITY_TYPE_TAG
 }
 
-type QuestShape = 'circle' | 'square' | 'pentagon' | 'hexagon' | 'gear';
+type QuestShape = 'circle' | 'square' | 'rsquare' | 'diamond' | 'pentagon' | 'hexagon' | 'octagon' | 'gear' | 'heart';
 
 type FtbId<T extends string> = `ftbquests:${T}` | T;
 
@@ -382,6 +382,21 @@ function truncateLong(value: Long | undefined) {
     return Number(value)
 }
 
+function iconBackgroundTexture(iconBackground: QuestShape | undefined) {
+	switch (iconBackground) {
+		case 'circle':	{ return 'heracles:textures/gui/quest_backgrounds/circles.png' }
+		case 'square':	{ return 'heracles:textures/gui/quest_backgrounds/squares.png' }
+		case 'rsquare': { return 'heracles:textures/gui/quest_backgrounds/rsquares.png' }
+		case 'diamond': { return 'heracles:textures/gui/quest_backgrounds/diamonds.png' }
+		case 'pentagon':{ return 'heracles:textures/gui/quest_backgrounds/pentagons.png' }
+		case 'hexagon': { return 'heracles:textures/gui/quest_backgrounds/hexagons.png' }
+		case 'octagon': { return 'heracles:textures/gui/quest_backgrounds/octagons.png' }
+		case 'gear': 		{ return 'heracles:textures/gui/quest_backgrounds/gears.png' }
+		case 'heart':		{ return 'heracles:textures/gui/quest_backgrounds/hearts.png' }
+		case undefined: { return undefined }
+	}
+}
+
 export const convertFtbQuests = async (input: QuestInputFileSystem, output: QuestOutputFileSystem) => {
     const readSNbtFile = async (name: string) =>
         parseStringifiedNbt(await input.readFile(name), name);
@@ -476,6 +491,8 @@ export const convertFtbQuests = async (input: QuestInputFileSystem, output: Ques
                 const questSubtitle = quest.subtitle ? formatString(quest.subtitle) : undefined;
                 const questIcon = quest.icon ? convertIcon(quest.icon) : inferredData?.icon;
 
+                const iconBackground = iconBackgroundTexture(quest.shape ?? chapter.default_quest_shape ?? questFile.default_quest_shape)
+
                 const heraclesQuest: HeraclesQuest = {
                     settings: {
                         hidden: quest.hide
@@ -511,9 +528,7 @@ export const convertFtbQuests = async (input: QuestInputFileSystem, output: Ques
 
                         icon: questIcon,
 
-                        icon_background: (quest.shape ?? chapter.default_quest_shape ?? questFile.default_quest_shape) === 'circle' ?
-                            'heracles:textures/gui/quest_backgrounds/circles.png' :
-                            undefined,
+                        icon_background: iconBackground,
 
                         subtitle: questSubtitle ? {
                             text: questSubtitle


### PR DESCRIPTION
In convertFtbQuests.ts:
- Expands `QuestShape` type def. to include default FTBQ shape options.
- Converts said default FTBQ shape options to a string to specify where to find matching textures.

In HeraclesQuest.ts:
- Changes `HeraclesQuest` type's `icon_background?` element to be type `string`

Note: Heracles currently ships with only two shapes; this patch is concerened only with Odysseus. It seemed better to preserve this information than to task a user with mapping the choices from FTQB chapter files to edits in corresponding multiple Heracles quest files.