### PR TITLE
Use specific background textures

### DIFF
--- a/odysseus/convertFtbQuests.ts
+++ b/odysseus/convertFtbQuests.ts
@@ -503,9 +503,14 @@ function truncateLong(value: Long | undefined) {
 function iconBackgroundTexture(
     iconBackground: QuestShape | undefined,
 ): ResourceLocation | undefined {
-    return iconBackground === undefined
-        ? undefined
-        : `heracles:textures/gui/quest_backgrounds/${iconBackground}s.png`;
+    if (!iconBackground || iconBackground === "square") {
+        return;
+    }
+
+    const textureName =
+        iconBackground === "rsquare" ? "rounded_square" : iconBackground;
+
+    return `heracles:textures/gui/quest_backgrounds/${textureName}s.png`;
 }
 
 export const convertFtbQuests = async (


### PR DESCRIPTION
For example, default when using 'square', converting 'rsquare' to 'rounded_square'
